### PR TITLE
Adress CLang warnings

### DIFF
--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -1384,7 +1384,6 @@ function(_juce_set_plugin_target_properties shared_code_target kind)
                 VERBATIM)
         else()
             add_executable(${target_name}_lv2_ttl_generator ${JUCE_SOURCE_DIR}/extras/Build/lv2_ttl_generator/lv2_ttl_generator.c)
-            set_source_files_properties(${JUCE_SOURCE_DIR}/extras/Build/lv2_ttl_generator/lv2_ttl_generator.c PROPERTIES LANGUAGE CXX)
             target_link_libraries(${target_name}_lv2_ttl_generator dl pthread)
             add_custom_command(TARGET ${target_name} POST_BUILD
                 COMMAND ${target_name}_lv2_ttl_generator "./${lv2_shared_lib}.so"

--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -567,7 +567,7 @@ public:
     //==============================================================================
     // Juce calls
 
-    void audioProcessorParameterChanged (AudioProcessor*, int index, float newValue)
+    void audioProcessorParameterChanged (AudioProcessor*, int index, float newValue) override
     {
         if (inParameterChangedCallback.get())
         {
@@ -592,7 +592,7 @@ public:
         }
     }
 
-    void audioProcessorChanged (AudioProcessor*, const ChangeDetails& details)
+    void audioProcessorChanged (AudioProcessor*, const ChangeDetails& details) override
     {
         if (details.programChanged && filter != nullptr && programsHost != nullptr)
         {
@@ -606,7 +606,7 @@ public:
         }
     }
 
-    void audioProcessorParameterChangeGestureBegin (AudioProcessor*, int parameterIndex)
+    void audioProcessorParameterChangeGestureBegin (AudioProcessor*, int parameterIndex) override
     {
         if (uiTouch == nullptr)
             return;
@@ -625,7 +625,7 @@ public:
         }
     }
 
-    void audioProcessorParameterChangeGestureEnd (AudioProcessor*, int parameterIndex)
+    void audioProcessorParameterChangeGestureEnd (AudioProcessor*, int parameterIndex) override
     {
         if (uiTouch == nullptr)
             return;
@@ -663,7 +663,7 @@ public:
         }
     }
 
-    void timerCallback()
+    void timerCallback() override
     {
         if (externalUI != nullptr && externalUI->isClosed())
         {


### PR DESCRIPTION
Surge XT builds with warnings are errors and currently
does not compile using the clang compiler.
This change should fix it and is basically a combo of
what came up in
https://github.com/surge-synthesizer/surge/issues/4488
and https://github.com/surge-synthesizer/surge/issues/4728