### PR TITLE
Replaced std::copy with std::memcpy to Copy Values with Pointers

### DIFF
--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -1146,7 +1146,7 @@ public:
 
                     if (i < numInChans && portAudioIns[i] != portAudioOuts[i])
                         //FloatVectorOperations::copy (portAudioOuts [i], portAudioIns[i], sampleCount);
-                        std::copy(portAudioOuts[i], portAudioOuts[i] + sampleCount, portAudioIns[i]);
+                        std::memcpy(portAudioOuts[i], portAudioIns[i], sizeof(float) * sampleCount);
                 }
 
                 for (; i < numInChans; ++i)


### PR DESCRIPTION
This is a substitution of juce::FloatVectorOperations::copy that has an error of calling ambiguous function on JUCE version 6.1.5.
std::copy is used for std::vector, and copying values with pointers uses std::memcpy.

