### PR TITLE
Definition and Style

### DIFF
--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -978,7 +978,7 @@ public:
         progDesc.name = nullptr;
     }
 
-    ~JuceLv2Wrapper ()
+    ~JuceLv2Wrapper()
     {
         const MessageManagerLock mmLock;
 
@@ -1405,7 +1405,7 @@ public:
                     aev->time.frames = midiEventPosition;
                     aev->body.type   = uridMidiEvent;
                     aev->body.size   = midiEventSize;
-                    memcpy (LV2_ATOM_BODY (&aev->body), midiEventData, midiEventSize);
+                    std::memcpy (LV2_ATOM_BODY (&aev->body), midiEventData, midiEventSize);
 
                     size    = lv2_atom_pad_size (sizeof (LV2_Atom_Event) + midiEventSize);
                     offset += size;
@@ -1720,7 +1720,7 @@ static void juceLV2_Activate (LV2_Handle handle)
     handlePtr->lv2Activate();
 }
 
-static void juceLV2_Run ( LV2_Handle handle, uint32 sampleCount)
+static void juceLV2_Run (LV2_Handle handle, uint32 sampleCount)
 {
     handlePtr->lv2Run (sampleCount);
 }
@@ -1908,13 +1908,13 @@ static const struct DescriptorCleanup {
 //==============================================================================
 // startup code..
 
-JUCE_EXPORTED_FUNCTION const LV2_Descriptor* lv2_descriptor (uint32 index)
+LV2_SYMBOL_EXPORT const LV2_Descriptor* lv2_descriptor (uint32 index)
 {
     return (index == 0) ? &JuceLv2Plugin : nullptr;
 }
 
 #if ! JUCE_AUDIOPROCESSOR_NO_GUI
-JUCE_EXPORTED_FUNCTION const LV2UI_Descriptor* lv2ui_descriptor (uint32 index)
+LV2_SYMBOL_EXPORT const LV2UI_Descriptor* lv2ui_descriptor (uint32 index)
 {
     switch (index)
     {

--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper_Exporter.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper_Exporter.cpp
@@ -43,7 +43,7 @@ static const String nameToSymbol (const String& name, const uint32 portIndex)
     if (trimmedName.isEmpty())
     {
         symbol += "lv2_port_";
-        symbol += String (portIndex+1);
+        symbol += String (portIndex + 1);
     }
     else
     {
@@ -145,7 +145,7 @@ static const String makeManifestFile (AudioProcessor* const filter, const String
     // Presets
     for (int i = 0; i < filter->getNumPrograms(); ++i)
     {
-        text += "<" + pluginURI + presetSeparator + "preset" + String::formatted ("%03i", i+1) + ">\n";
+        text += "<" + pluginURI + presetSeparator + "preset" + String::formatted ("%03i", i + 1) + ">\n";
         text += "    a pset:Preset ;\n";
         text += "    lv2:appliesTo <" + pluginURI + "> ;\n";
         text += "    rdfs:label \"" + filter->getProgramName (i) + "\" ;\n";
@@ -290,10 +290,10 @@ static const String makePluginFile (AudioProcessor* const filter, const int maxN
 
         text += "        a lv2:InputPort, lv2:AudioPort ;\n";
         text += "        lv2:index " + String (portIndex++) + " ;\n";
-        text += "        lv2:symbol \"lv2_audio_in_" + String (i+1) + "\" ;\n";
-        text += "        lv2:name \"Audio Input " + String (i+1) + "\" ;\n";
+        text += "        lv2:symbol \"lv2_audio_in_" + String (i + 1) + "\" ;\n";
+        text += "        lv2:name \"Audio Input " + String (i + 1) + "\" ;\n";
 
-        if (i+1 == maxNumInputChannels)
+        if (i + 1 == maxNumInputChannels)
             text += "    ] ;\n\n";
         else
             text += "    ] ,\n";
@@ -309,10 +309,10 @@ static const String makePluginFile (AudioProcessor* const filter, const int maxN
 
         text += "        a lv2:OutputPort, lv2:AudioPort ;\n";
         text += "        lv2:index " + String (portIndex++) + " ;\n";
-        text += "        lv2:symbol \"lv2_audio_out_" + String (i+1) + "\" ;\n";
-        text += "        lv2:name \"Audio Output " + String (i+1) + "\" ;\n";
+        text += "        lv2:symbol \"lv2_audio_out_" + String (i + 1) + "\" ;\n";
+        text += "        lv2:name \"Audio Output " + String (i + 1) + "\" ;\n";
 
-        if (i+1 == maxNumOutputChannels)
+        if (i + 1 == maxNumOutputChannels)
             text += "    ] ;\n\n";
         else
             text += "    ] ,\n";
@@ -336,7 +336,7 @@ static const String makePluginFile (AudioProcessor* const filter, const int maxN
         if (paramName.isNotEmpty())
             text += "        lv2:name \"" + paramName + "\" ;\n";
         else
-            text += "        lv2:name \"Port " + String (i+1) + "\" ;\n";
+            text += "        lv2:name \"Port " + String (i + 1) + "\" ;\n";
 
         text += "        lv2:default " + String::formatted ("%f", safeParamValue (parameters[i]->getValue())) + " ;\n";
         text += "        lv2:minimum 0.0 ;\n";
@@ -345,7 +345,7 @@ static const String makePluginFile (AudioProcessor* const filter, const int maxN
         if (! parameters[i]->isAutomatable())
             text += "        lv2:portProperty <" LV2_PORT_PROPS__expensive "> ;\n";
 
-        if (i+1 == parameters.size())
+        if (i + 1 == parameters.size())
             text += "    ] ;\n\n";
         else
             text += "    ] ,\n";
@@ -398,14 +398,14 @@ static const String makePresetsFile (AudioProcessor* const filter)
 
     for (int i = 0; i < numPrograms; ++i)
     {
-        std::cout << "\nSaving preset " << i+1 << "/" << numPrograms+1 << "...";
+        std::cout << "\nSaving preset " << i + 1 << "/" << numPrograms + 1 << "...";
         std::cout.flush();
 
         String preset;
 
         // Label
         filter->setCurrentProgram (i);
-        preset += "<" + pluginURI + presetSeparator + "preset" + String::formatted ("%03i", i+1) + "> a pset:Preset ;\n";
+        preset += "<" + pluginURI + presetSeparator + "preset" + String::formatted ("%03i", i + 1) + "> a pset:Preset ;\n";
 
         // State
 #if JucePlugin_WantsLV2State
@@ -448,7 +448,7 @@ static const String makePresetsFile (AudioProcessor* const filter)
             preset += "        lv2:symbol \"" + nameToSymbol (parameters[j]->getName (1024), static_cast<unsigned int> (j)) + "\" ;\n";
             preset += "        pset:value " + String::formatted ("%f", safeParamValue (parameters[j]->getValue())) + " ;\n";
 
-            if (j+1 == filter->getParameters().size())
+            if (j + 1 == filter->getParameters().size())
                 preset += "    ] ";
             else
                 preset += "    ] ,\n";

--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_LV2.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_LV2.cpp
@@ -2,17 +2,16 @@
   ==============================================================================
 
    This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+   Copyright (c) 2020 - Raw Material Software Limited
 
    JUCE is an open source library subject to commercial or open-source
    licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+   By using JUCE, you agree to the terms of both the JUCE 6 End-User License
+   Agreement and JUCE Privacy Policy (both effective as of the 16th June 2020).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+   End User License Agreement: www.juce.com/juce-6-licence
+   Privacy Policy: www.juce.com/juce-privacy-policy
 
    Or: You may also use this code under the terms of the GPL v3 (see
    www.gnu.org/licenses).


### PR DESCRIPTION
When importing a LV2 symbol, LV2_SYMBOL_EXPORT is preferred to ensure existence of the symbol in the linking process.

[Link for Description of LV2_SYMBOL_EXPORT](https://lv2plug.in/doc/html/group__lv2core.html#ga05eb2f14429fd6ae501265b5e5af8309)

[LV2_SYMBOL_EXPORT is in lv2.h (Github).](https://github.com/lv2/lv2/blob/master/lv2/core/lv2.h)

Note LV2_SYMBOL_EXPORT defined only with _WIN32 for Windows. However, _WIN32 is also defined for 64-bit build along with _WIN64. [Here is the discussion about _WIN32 and _WIN64 in Stack Overflow](https://stackoverflow.com/questions/6679396/should-i-define-both-win32-and-win64-in-64bit-build), and [the official document of Microsoft about predefined macros.](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros)

You would also find out these declarations marking LV2_SYMBOL_EXPORT in your Linux system:
/usr/lib/lv2/core.lv2/lv2.h for lv2_descriptor
and
/usr/lib/lv2/ui.lv2/ui.h for lv2ui_descriptor

Raw Material Software Limited has the master of JUCE since 2020, and the holder has the right of licensing with either GPLv3 or proprietary.